### PR TITLE
Optimize distances

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -35,7 +35,8 @@ Imports:
     RCurl,
     jsonlite,
     cli,
-    glue
+    glue,
+    dbscan
 RoxygenNote: 7.1.1.9000
 Roxygen: list(markdown = TRUE)
 Suggests:

--- a/tests/testthat/test-osm_enrich.R
+++ b/tests/testthat/test-osm_enrich.R
@@ -25,5 +25,5 @@ test_that("enrich_osm() test if example enrichment works", {
       measure = "spherical"
     )
 
-  expect_equal(class(sf_enriched$waste_baskets), "integer")
+  expect_equal(class(sf_enriched$waste_baskets), "numeric")
 })


### PR DESCRIPTION
Code optimized to find the potential neighbors within a radius using KD-trees (from the dbscan library, a new dependency), instead of calculating distances to all possible neighbors using sf (slow). Those distances can be used directly passing the argument exact_distances = FALSE.